### PR TITLE
Version 7.2 enteprise

### DIFF
--- a/jss-in-a-box-redhat.sh
+++ b/jss-in-a-box-redhat.sh
@@ -95,7 +95,8 @@ WhichDistAmI()
 	# This script is currently designed for Ubuntu only, so let's fail gracefully if we're running on anything else.
 
 	# Check for version
-	version=$( cat /etc/redhat-release | awk '{ print $4 }' | cut -c 1 )
+	version=$( cat /etc/redhat-release | awk '{ print $7 }' | cut -c 1 )
+
 
 	# Is this RedHat 7 server?
 	if [[ $version != "7" ]];


### PR DESCRIPTION
Line 99 version is currently outputting L, my 7.2 box outputs: Red Hat Enterprise Linux Server release 7.2 (Maipo) as the version string, so proposing to print $7
